### PR TITLE
Deutsche Lizenz

### DIFF
--- a/LIZENZ
+++ b/LIZENZ
@@ -1,13 +1,13 @@
-        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-                    Version 2, December 2004
+        ÖFFENTLICHE TU WAS DU VERDAMMT NOCH MAL WILLST-LIZENZ
+                    Version 1, September 2021
 
- Copyright (C) 2021 Benjamin Bouvier <email missing>
+ Copyright (C) 2021 kleines Filmröllchen
 
- Everyone is permitted to copy and distribute verbatim or modified
- copies of this license document, and changing it is allowed as long
- as the name is changed.
+ Jedem ist es gestattet, diese Lizenz zu kopieren und identische oder
+ modifizierte Kopien dieses Lizenzdokuments zu verbreiten, und seine
+ Änderung ist erlaubt, solange der Name geändert wird.
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+        ÖFFENTLICHE TU WAS DU VERDAMMT NOCH MAL WILLST-LIZENZ
+   GESCHÄFTSBEDINGUNGEN FÜR DAS KOPIEREN, VERBREITEN UND MODIFIZIEREN
 
-  0. You just DO WHAT THE FUCK YOU WANT TO.
+  0. Du tust einfach, WAS DU VERDAMMT NOCH MAL WILLST.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ here and there, and open a pull-request against the `hauptzweig` (German for
 
 ## Die Lizenzbestimmungen
 
-[WTFPL](http://www.wtfpl.net/).
+[WTFPL](http://www.wtfpl.net/). The images do not fall under this license, see below.
 
 Image attributions:
 * "Brezel und Filzhut zum Oktoberfest" by Tim Reckmann | a59.de is licensed under CC BY 2.0


### PR DESCRIPTION
Diese Lizenz ist eine Übersetzung der Originallizenz, mit dem Kurznamen "ÖVNML" (öffentliche verdammt-noch-mal-Lizenz). Außerdem wurde README.md aktualisiert, um darauf hinzuweisen, dass die Bilder nicht unter die Lizenz fallen (ist auch mit englischer Lizenz notwendig, da WTFPL nicht mit CC kompatibel ist).