### PR TITLE
Verbessere das LIESMICH

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ syntax. Gut so!
 First of all, _vielen Dank_ for considering participating to this joke, the
 German government will thank you later! Feel free to throw in a few identifiers
 here and there, and open a pull-request against the `hauptzweig` (German for
-`main`) branch. The initial translation was made by [Shemnei](https://github.com/Shemnei/) and [michidk](https://github.com/michidk/).
+`main branch`). The initial translation was made by [Shemnei](https://github.com/Shemnei/) and [michidk](https://github.com/michidk/).
 
 ## Die Lizenzbestimmungen
 


### PR DESCRIPTION
Hauptzweig bedeutet "main branch", nicht nur "main". Besser wäre es natürlich der Zweig würde nur "Haupt" heissen.