### PR TITLE
Erlaube verkürzte Schreibweise "fk" für "funktion"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ rost::rost! {
     benutze std::sammlungen::Wörterbuch als Wöbu;
 
     eigenschaft SchlüsselWert {
-        funktion schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette);
-        funktion lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette>;
+        fk schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette);
+        fk lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette>;
     }
 
     statisch änd WÖRTERBUCH: Möglichkeit<Wöbu<Zeichenkette, Zeichenkette>> = Nichts;
@@ -34,14 +34,14 @@ rost::rost! {
 
     umstz SchlüsselWert für Konkret {
 
-        funktion schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette) {
+        fk schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette) {
             lass wöbu = gefährlich {
                 WÖRTERBUCH.hole_oder_füge_ein_mit(Standard::standard)
             };
             wöbu.einfügen(schlsl, wert);
         }
 
-        funktion lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette> {
+        fk lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette> {
             wenn lass Etwas(wöbu) = gefährlich { WÖRTERBUCH.als_ref() } {
                 Gut(wöbu.hole(&schlsl))
             } anderenfalls {

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -2,8 +2,8 @@ rost::rost! {
     benutze std::sammlungen::Wörterbuch als Wöbu;
 
     eigenschaft SchlüsselWert {
-        funktion schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette);
-        funktion lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette>;
+        fk schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette);
+        fk lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette>;
     }
 
     statisch änd WÖRTERBUCH: Möglichkeit<Wöbu<Zeichenkette, Zeichenkette>> = Nichts;
@@ -12,14 +12,14 @@ rost::rost! {
 
     umstz SchlüsselWert für Konkret {
 
-        funktion schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette) {
+        fk schreibe(&selbst, schlsl: Zeichenkette, wert: Zeichenkette) {
             lass wöbu = gefährlich {
                 WÖRTERBUCH.hole_oder_füge_ein_mit(Standard::standard)
             };
             wöbu.einfügen(schlsl, wert);
         }
 
-        funktion lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette> {
+        fk lese(&selbst, schlsl: Zeichenkette) -> Ergebnis<Möglichkeit<&Zeichenkette>, Zeichenkette> {
             wenn lass Etwas(wöbu) = gefährlich { WÖRTERBUCH.als_ref() } {
                 Gut(wöbu.hole(&schlsl))
             } anderenfalls {
@@ -28,7 +28,7 @@ rost::rost! {
         }
     }
 
-    öffentlich(kiste) funktion vielleicht(i: u32) -> Möglichkeit<Ergebnis<u32, Zeichenkette>> {
+    öffentlich(kiste) fk vielleicht(i: u32) -> Möglichkeit<Ergebnis<u32, Zeichenkette>> {
         wenn i % 2 == 1 {
             wenn i == 42 {
                 Etwas(Fehler(Zeichenkette::von("Scheiße")))
@@ -40,14 +40,14 @@ rost::rost! {
         }
     }
 
-    asynchron funktion beispiel() {
+    asynchron fk beispiel() {
     }
 
-    asynchron funktion beispiel2() {
+    asynchron fk beispiel2() {
         beispiel().abwarten;
     }
 
-    funktion einstieg() {
+    fk einstieg() {
         lass änd x = 31;
 
         entspreche x {
@@ -86,4 +86,3 @@ rost::rost! {
             });
     }
 }
-

--- a/rost_proc_macro/src/lib.rs
+++ b/rost_proc_macro/src/lib.rs
@@ -39,7 +39,7 @@ fn replace_ident(ident: Ident) -> Option<TokenTree> {
         "ea" => "io",
         "extern" => "extern",
         "falsch" => "false",
-        "funktion" => "fn",
+        "funktion" | "fk" => "fn",
         "übergeordnet" | "uebergeordnet" => "super",
         "einfügen" | "einfuegen" => "insert",
 


### PR DESCRIPTION
In dem folgenden Kommentar gab es den Vorschlag für diese Änderung: [#12 (Kommentar)](https://github.com/michidk/rost/pull/12#issuecomment-2661581989)
> Könnte man eventuell das Schlüsselwort `funktion` zu etwas kürzerem umbenennen? Ich schlage `fk` vor.
Da ich selbige Änderung vorschlagen möchte und seitdem keine Code-Übernahmeanfrage geöffnet wurde, möchte ich dies hiermit erledigen.

Mit dieser Änderung wird `fk`, neben der vorhandenen Übersetzung `funktion`, als weiteren Begriff für das originale Schlüsselwort `function` hinzugefügt.
Außerderm wurde die [LESEMICH.md](https://github.com/Kesuaheli/rost/blob/4fd57d304de1c9f2361f4ae473303c872fe4f429/README.md) Datei angepasst sowie der [Beispielquellcode](https://github.com/Kesuaheli/rost/blob/4fd57d304de1c9f2361f4ae473303c872fe4f429/examples/src/main.rs) überarbeitet, welche nun die neue Übersetzung `fk` verwenden.